### PR TITLE
Updated reference to folderCreator

### DIFF
--- a/src/helpers/fileSyncHelper.ts
+++ b/src/helpers/fileSyncHelper.ts
@@ -8,7 +8,7 @@ import {IFileInfo} from './../utils/IFileInfo';
 import {ISettings, IDigest} from './../utils/ISettings';
 
 import {defer, IDeferred} from './defer';
-import {FolderCreator} from './FolderCreator';
+import {FolderCreator} from './folderCreator';
 
 import * as fileHelper from './fileHelper';
 let fileHlp = new fileHelper.FileHelper();


### PR DESCRIPTION
Within docker, gulp-spsync-creds throws an error saying, module name ./FolderCreator could not be found. Renaming it to ./folderCreator (small case F) helped resolve the error. Below is error from the console.

> > samplesharepointapp@1.0.0 start /code
> > gulp watch
> 
> module.js:471
>     throw err;
>     ^
> 
> Error: Cannot find module './FolderCreator'
>     at Function.Module._resolveFilename (module.js:469:15)
>     at Function.Module._load (module.js:417:25)
>     at Module.require (module.js:497:17)
>     at require (internal/module.js:20:19)
>     at Object.<anonymous> (/code/node_modules/gulp-spsync-creds/release/helpers/fileSyncHelper.js:7:23)
>     at Module._compile (module.js:570:32)
>     at Object.Module._extensions..js (module.js:579:10)
>     at Module.load (module.js:487:32)
>     at tryModuleLoad (module.js:446:12)
>     at Function.Module._load (module.js:438:3)
>     at Module.require (module.js:497:17)
>     at require (internal/module.js:20:19)
>     at Object.<anonymous> (/code/node_modules/gulp-spsync-creds/release/index.js:5:24)
>     at Module._compile (module.js:570:32)
>     at Object.Module._extensions..js (module.js:579:10)
>     at Module.load (module.js:487:32)
> 
> npm ERR! Linux 4.9.12-moby
> npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "start"
> npm ERR! node v6.10.0
> npm ERR! npm  v3.10.10
> npm ERR! code ELIFECYCLE
> npm ERR! samplesharepointapp@1.0.0 start: `gulp watch`
> npm ERR! Exit status 1
> npm ERR!
> npm ERR! Failed at the samplesharepointapp@1.0.0 start script 'gulp watch'.
> npm ERR! Make sure you have the latest version of node.js and npm installed.
> npm ERR! If you do, this is most likely a problem with the samplesharepointapp package,
> npm ERR! not with npm itself.
> npm ERR! Tell the author that this fails on your system:
> npm ERR!     gulp watch
> npm ERR! You can get information on how to open an issue for this project with:
> npm ERR!     npm bugs samplesharepointapp
> npm ERR! Or if that isn't available, you can get their info via:
> npm ERR!     npm owner ls samplesharepointapp
> npm ERR! There is likely additional logging output above.
> 
> npm ERR! Please include the following file with any support request:
> npm ERR!     /code/npm-debug.log